### PR TITLE
[Version 2] Refactor plugin to leverage project name convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,33 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "Build My Service"
     plugins:
-      - docker-compose#v3.8.0:
+      - docker-compose#v5.9.0:
           build: my-service
-      - envato/docker-size-annotation#v1.0.0: ~
+      - envato/docker-size-annotation#v2.0.0:
+          annotate: my-service
+```
+
+or
+
+```yml
+steps:
+  - label: "Build My Services"
+    plugins:
+      - docker-compose#v5.9.0:
+          build:
+            - my-service
+            - my-service2
+      - envato/docker-size-annotation#v2.0.0:
+          annotate:
+            - my-service
+            - my-service2
 ```
 
 ## Configuration
 
-n/a
+`annotate`
+
+The name of a service(s) to annotate. Either a single service or multiple services can be provided as an array.
 
 ## Developing
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -27,8 +27,8 @@ function docker_compose_project_name() {
   echo "buildkite${BUILDKITE_JOB_ID//-}"
 }
 
-if [[ -n "$(plugin_read_list IMAGES)" ]]; then
-  for image in $(plugin_read_list IMAGES); do
+if [[ -n "$(plugin_read_list ANNOTATE)" ]]; then
+  for image in $(plugin_read_list ANNOTATE); do
     tag="$(docker_compose_project_name)-${image}"
     context="image_size_${tag}"
     echo "Using tag: ${tag} and context: ${context}"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,23 +1,38 @@
 #!/bin/bash
 set -euo pipefail
 
-# The docker compose plugin tags images by generating an additional docker compose file
-# https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/blob/db3fba294d9126661e641136a0841cdf08796a19/commands/build.sh#L64-L67
-DOCKER_COMPOSE_OVERRIDE="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
 
-if [ -f "$DOCKER_COMPOSE_OVERRIDE" ]; then
-  echo "Running image size annotation"
-  tags=$(awk '{$1=$1;print}' < "$DOCKER_COMPOSE_OVERRIDE" | awk -F ": " '$1 ~ /image/ { print $2 }')
+function plugin_read_list() {
+  prefix_read_list "BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_$1"
+}
 
-  tags_array=()
-  while IFS= read -r tag; do
-    tags_array+=("$tag")
-  done <<< "$tags"
+function prefix_read_list() {
+  local prefix="$1"
+  local parameter="${prefix}_0"
 
-  for tag in "${tags_array[@]}"; do
-    context=$(echo "${tag}" | awk -F ":" '{print $2}')
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      echo "${!parameter}"
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  elif [[ -n "${!prefix:-}" ]]; then
+    echo "${!prefix}"
+  fi
+}
+
+function docker_compose_project_name() {
+  echo "buildkite${BUILDKITE_JOB_ID//-}"
+}
+
+if [[ -n "$(plugin_read_list IMAGES)" ]]; then
+  for image in $(plugin_read_list IMAGES); do
+    tag="$(docker_compose_project_name)-${image}"
+    context="image_size_${tag}"
     echo "Using tag: ${tag} and context: ${context}"
     message=$(docker images --format "**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})" "$tag")
-    echo "${message:-Unknown}" | buildkite-agent annotate --style info --context "${context}-size"
+    echo "${message:-Unknown}" | buildkite-agent annotate --style info --context "${context}"
   done
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -32,7 +32,7 @@ if [[ -n "$(plugin_read_list IMAGES)" ]]; then
     tag="$(docker_compose_project_name)-${image}"
     context="image_size_${tag}"
     echo "Using tag: ${tag} and context: ${context}"
-    message=$(docker images --format "**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})" "$tag")
+    message=$(docker images --format "**${BUILDKITE_LABEL}** - *${image}* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})" "$tag")
     echo "${message:-Unknown}" | buildkite-agent annotate --style info --context "${context}"
   done
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,5 +4,8 @@ author: https://github.com/envato/docker-size-annotation-buildkite-plugin
 requirements:
   - docker
 configuration:
-  properties: {}
+  properties:
+    images:
+      type: [string, array]
+      minimum: 1
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,7 +5,7 @@ requirements:
   - docker
 configuration:
   properties:
-    images:
+    annotate:
       type: [string, array]
       minimum: 1
   additionalProperties: false

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -11,7 +11,7 @@ setup() {
 @test "Annotates a single build" {
   export BUILDKITE_LABEL="My Label"
   export BUILDKITE_JOB_ID=0123456789abcedf
-  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES="my-service"
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_ANNOTATE="my-service"
 
   stub docker \
     "images --format \"**${BUILDKITE_LABEL}** - *my-service* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
@@ -30,7 +30,7 @@ setup() {
 @test "Annotates a single build (via array)" {
   export BUILDKITE_LABEL="My Label"
   export BUILDKITE_JOB_ID=0123456789abcedf
-  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_0="my-service"
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_ANNOTATE_0="my-service"
 
   stub docker \
     "images --format \"**${BUILDKITE_LABEL}** - *my-service* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
@@ -49,8 +49,8 @@ setup() {
 @test "Annotates a many build" {
   export BUILDKITE_LABEL="My Label"
   export BUILDKITE_JOB_ID=0123456789abcedf
-  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_0="my-service"
-  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_1="my-service2"
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_ANNOTATE_0="my-service"
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_ANNOTATE_1="my-service2"
 
   stub docker \
     "images --format \"**${BUILDKITE_LABEL}** - *my-service* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB" \

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,30 +1,25 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
 
-# Uncomment the following line to debug stub failures
-# export DOCKER_STUB_DEBUG=/dev/tty
-# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+  # Uncomment the following line to debug stub failures
+  # export DOCKER_STUB_DEBUG=/dev/tty
+  # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+}
 
-@test "Annotates a single services" {
+@test "Annotates a single build" {
   export BUILDKITE_LABEL="My Label"
-  export BUILDKITE_BUILD_NUMBER=1000
-  FILE="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
-  cat <<EOT > $FILE
-version: '2.4'
-services:
-  my-service:
-    image: XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:project-my-service-build-1000
-EOT
+  export BUILDKITE_JOB_ID=0123456789abcedf
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES="my-service"
 
   stub docker \
-    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:project-my-service-build-1000\" : echo 5MB"
+    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
 
   stub buildkite-agent \
-    "annotate --style info --context \"project-my-service-build-1000-size\" : exit 0"
+    "annotate --style info --context \"image_size_buildkite0123456789abcedf-my-service\" : exit 0"
 
   run "$PWD/hooks/post-command"
-  rm -f $FILE
 
   assert_success
 
@@ -32,30 +27,40 @@ EOT
   unstub buildkite-agent
 }
 
-
-@test "Annotates many services" {
+@test "Annotates a single build (via array)" {
   export BUILDKITE_LABEL="My Label"
-  export BUILDKITE_BUILD_NUMBER=2000
-  FILE="docker-compose.buildkite-${BUILDKITE_BUILD_NUMBER}-override.yml"
-  cat <<EOT > $FILE
-version: '2.4'
-services:
-  my-service:
-    image: XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:project-my-service-build-2000
-  my-service2:
-    image: XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:project-my-service2-build-2000
-EOT
+  export BUILDKITE_JOB_ID=0123456789abcedf
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_0="my-service"
 
   stub docker \
-    "images --format \"**My Label** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:project-my-service-build-2000\" : echo 5MB" \
-    "images --format \"**My Label** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"XXXXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/my-repo:project-my-service2-build-2000\" : echo 10MB"
+    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
 
   stub buildkite-agent \
-    "annotate --style info --context \"project-my-service-build-2000-size\" : exit 0" \
-    "annotate --style info --context \"project-my-service2-build-2000-size\" : exit 0"
+    "annotate --style info --context \"image_size_buildkite0123456789abcedf-my-service\" : exit 0"
 
   run "$PWD/hooks/post-command"
-  rm -f $FILE
+
+  assert_success
+
+  unstub docker
+  unstub buildkite-agent
+}
+
+@test "Annotates a many build" {
+  export BUILDKITE_LABEL="My Label"
+  export BUILDKITE_JOB_ID=0123456789abcedf
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_0="my-service"
+  export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_1="my-service2"
+
+  stub docker \
+    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB" \
+    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service2\" : echo 10MB"
+
+  stub buildkite-agent \
+    "annotate --style info --context \"image_size_buildkite0123456789abcedf-my-service\" : exit 0" \
+    "annotate --style info --context \"image_size_buildkite0123456789abcedf-my-service2\" : exit 0"
+
+  run "$PWD/hooks/post-command"
 
   assert_success
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -14,7 +14,7 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES="my-service"
 
   stub docker \
-    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
+    "images --format \"**${BUILDKITE_LABEL}** - *my-service* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
 
   stub buildkite-agent \
     "annotate --style info --context \"image_size_buildkite0123456789abcedf-my-service\" : exit 0"
@@ -33,7 +33,7 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_0="my-service"
 
   stub docker \
-    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
+    "images --format \"**${BUILDKITE_LABEL}** - *my-service* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB"
 
   stub buildkite-agent \
     "annotate --style info --context \"image_size_buildkite0123456789abcedf-my-service\" : exit 0"
@@ -53,8 +53,8 @@ setup() {
   export BUILDKITE_PLUGIN_DOCKER_SIZE_ANNOTATION_IMAGES_1="my-service2"
 
   stub docker \
-    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB" \
-    "images --format \"**${BUILDKITE_LABEL}** docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service2\" : echo 10MB"
+    "images --format \"**${BUILDKITE_LABEL}** - *my-service* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service\" : echo 5MB" \
+    "images --format \"**${BUILDKITE_LABEL}** - *my-service2* docker image is **{{.Size}}** (Tag {{.Tag}} ID {{.ID}})\" \"buildkite0123456789abcedf-my-service2\" : echo 10MB"
 
   stub buildkite-agent \
     "annotate --style info --context \"image_size_buildkite0123456789abcedf-my-service\" : exit 0" \


### PR DESCRIPTION
Relying on the override file as produced by https://github.com/buildkite-plugins/docker-compose-buildkite-plugin has become flaky.

This refactor relies instead on the docker compose project naming convention for finding the images on the host.

A side effect is that we now need to explicitly list the services (as `annotate`)